### PR TITLE
Provide shell launch with mount points

### DIFF
--- a/doodad/launch_tools.py
+++ b/doodad/launch_tools.py
@@ -13,7 +13,7 @@ def launch_shell(
     ):
     if mount_points is None:
         mount_points = []
-    mode.launch_command(command, dry=dry)
+    mode.launch_command(command, dry=dry, mount_points=mount_points)
 
 
 def launch_python(


### PR DESCRIPTION
Spotted a bug with launching shell commands, looks like the method just wasn't being fed the mount points.